### PR TITLE
feat: ロビー発見・接続 UX (B-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "parking",
- "polling",
+ "polling 3.11.0",
  "rustix 1.1.3",
  "slab",
  "windows-sys 0.61.2",
@@ -940,7 +940,7 @@ checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
  "bitflags 2.11.0",
  "log",
- "polling",
+ "polling 3.11.0",
  "rustix 0.38.44",
  "slab",
  "thiserror 1.0.69",
@@ -1635,6 +1635,7 @@ dependencies = [
  "cplp-network",
  "cplp-session",
  "jsonwebtoken",
+ "reqwest",
  "serde_json",
  "tokio",
  "tracing",
@@ -1728,7 +1729,9 @@ dependencies = [
  "axum-extra",
  "axum-test",
  "cplp-core",
+ "hostname",
  "jsonwebtoken",
+ "mdns-sd",
  "oauth2",
  "reqwest",
  "serde",
@@ -1794,6 +1797,7 @@ dependencies = [
  "cplp-core",
  "cplp-network",
  "futures-util",
+ "mdns-sd",
  "reqwest",
  "serde",
  "serde_json",
@@ -2053,7 +2057,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2234,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2354,6 +2358,17 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -3018,6 +3033,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,7 +3178,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3172,7 +3198,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3296,6 +3322,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3745,6 +3781,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36e83ad165be7e0ad2e3ae3be9afffdda0c2c9a7e70c628e5541f11443e3041"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "polling 2.8.0",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4077,7 +4127,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4209,7 +4259,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -4836,6 +4886,22 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
@@ -5040,7 +5106,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5079,9 +5145,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5780,7 +5846,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5847,7 +5913,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6288,6 +6354,16 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -6735,7 +6811,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6940,7 +7016,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8070,7 +8146,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8275,6 +8351,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8322,6 +8407,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -8374,6 +8474,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8392,6 +8498,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8407,6 +8519,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8440,6 +8558,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8455,6 +8579,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8476,6 +8606,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8491,6 +8627,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,9 @@ jsonwebtoken = "9"
 # HTTP クライアント
 reqwest = { version = "0.12", features = ["json"] }
 
+# mDNS サービス発見
+mdns-sd = "0.12"
+
 # WebSocket クライアント
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 futures-util = "0.3"

--- a/crates/cplp-app/Cargo.toml
+++ b/crates/cplp-app/Cargo.toml
@@ -25,3 +25,4 @@ tracing-appender.workspace = true
 clap = { version = "4", features = ["derive"] }
 jsonwebtoken.workspace = true
 serde_json.workspace = true
+reqwest.workspace = true

--- a/crates/cplp-app/src/main.rs
+++ b/crates/cplp-app/src/main.rs
@@ -118,6 +118,21 @@ enum LobbyCmd {
         #[arg(short, long, default_value_t = 3000)]
         port: u16,
     },
+    /// リモートロビーに接続テスト
+    #[command(name = "connect")]
+    LobbyConnect {
+        /// ロビーサーバー URL (例: http://192.168.1.10:3000)
+        url: String,
+        /// JWT トークン（省略時は dev トークン生成）
+        #[arg(long)]
+        token: Option<String>,
+    },
+    /// LAN 内のロビーサーバーを自動発見
+    Discover {
+        /// 発見タイムアウト (秒)
+        #[arg(short, long, default_value_t = 5)]
+        timeout: u64,
+    },
     /// グループ一覧を取得
     Groups {
         /// ロビーサーバー URL
@@ -497,6 +512,87 @@ async fn handle_lobby(cmd: LobbyCmd) -> anyhow::Result<()> {
                          または直接起動: LOBBY_MODE={mode} cargo run -p cplp-lobby"
                     );
                 }
+            }
+        }
+        LobbyCmd::LobbyConnect { url, token } => {
+            println!("ロビー接続テスト: {url}");
+
+            // 1. ヘルスチェック
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .build()?;
+
+            match client.get(format!("{}/health", url)).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    println!("  ✓ ヘルスチェック OK");
+                }
+                Ok(resp) => {
+                    anyhow::bail!(
+                        "ヘルスチェック失敗: HTTP {} ({})",
+                        resp.status(),
+                        url
+                    );
+                }
+                Err(e) => {
+                    if e.is_timeout() {
+                        anyhow::bail!("接続タイムアウト: {url} (5秒以内に応答なし)");
+                    } else if e.is_connect() {
+                        anyhow::bail!("接続拒否: {url} (サーバーが起動していない可能性があります)");
+                    } else {
+                        anyhow::bail!("接続エラー: {e}");
+                    }
+                }
+            }
+
+            // 2. グループ一覧取得
+            let token = resolve_token(token)?;
+            let lobby = LobbyClient::new(LobbyConfig {
+                base_url: url.clone(),
+                token,
+                local_addr: "[::1]:0".parse().unwrap(),
+            });
+
+            match lobby.list_groups().await {
+                Ok(groups) => {
+                    println!("  ✓ 認証 OK");
+                    if groups.is_empty() {
+                        println!("\n  グループなし（新規作成可能）");
+                    } else {
+                        println!("\n  {} 個のグループ:", groups.len());
+                        for g in &groups {
+                            println!("    {} — {}", g.id, g.name);
+                        }
+                    }
+                }
+                Err(e) => {
+                    println!("  ✗ グループ取得失敗: {e}");
+                    println!("    ヘルスチェックは通過したので、認証トークンを確認してください");
+                }
+            }
+
+            println!("\n接続先: {url}");
+        }
+        LobbyCmd::Discover { timeout } => {
+            println!(
+                "LAN 内のロビーサーバーを検索中 ({timeout}秒)..."
+            );
+
+            let lobbies = cplp_session::discover_lobbies(
+                std::time::Duration::from_secs(timeout),
+            )
+            .await?;
+
+            if lobbies.is_empty() {
+                println!("\nロビーサーバーが見つかりませんでした");
+                println!("ヒント: `cplp session lobby start` でローカルサーバーを起動してください");
+            } else {
+                println!("\n{} 個のロビーサーバーが見つかりました:\n", lobbies.len());
+                for lobby in &lobbies {
+                    println!("  {} (mode: {}, v{})", lobby.url, lobby.mode, lobby.version);
+                    println!("    名前: {}", lobby.name);
+                }
+                println!();
+                println!("接続テスト: cplp session lobby connect <URL>");
             }
         }
         LobbyCmd::Groups { url, token } => {

--- a/crates/cplp-hud/src/state.rs
+++ b/crates/cplp-hud/src/state.rs
@@ -81,6 +81,10 @@ pub struct SessionSnapshot {
     pub remote_plugin: String,
     pub mix_local: f32,
     pub mix_remote: f32,
+    /// 接続先ロビー URL (空文字列 = ロビー未使用)
+    pub lobby_url: String,
+    /// ロビー接続状態
+    pub lobby_connected: bool,
 }
 
 #[cfg(test)]
@@ -126,6 +130,7 @@ mod tests {
             remote_plugin: "Vital".into(),
             mix_local: 0.7,
             mix_remote: 0.3,
+            ..Default::default()
         });
         let snap = output.read();
         assert_eq!(snap.peer_name, "Player B");

--- a/crates/cplp-hud/src/visuals/connection.rs
+++ b/crates/cplp-hud/src/visuals/connection.rs
@@ -112,6 +112,45 @@ impl ConnectionIndicator {
             size: font_size,
             color: [lat_color.r, lat_color.g, lat_color.b, lat_color.a],
         });
+
+        // ロビー接続状態（レイテンシの左に表示、ロビー使用時のみ）
+        if !self.snapshot.lobby_url.is_empty() {
+            let lobby_dot_color = if self.snapshot.lobby_connected {
+                Color {
+                    r: 0.3,
+                    g: 0.7,
+                    b: 1.0,
+                    a: 1.0,
+                } // 青
+            } else {
+                Color {
+                    r: 0.5,
+                    g: 0.5,
+                    b: 0.5,
+                    a: 1.0,
+                } // グレー
+            };
+            let lobby_text = format!("● {}", self.snapshot.lobby_url);
+            let lobby_width = lobby_text.len() as f32 * theme::CHAR_W;
+            renderer.text(TextEntry {
+                text: lobby_text,
+                x: rect.x + rect.w
+                    - padding
+                    - jitter_width
+                    - padding
+                    - latency_width
+                    - padding
+                    - lobby_width,
+                y: text_y,
+                size: font_size,
+                color: [
+                    lobby_dot_color.r,
+                    lobby_dot_color.g,
+                    lobby_dot_color.b,
+                    lobby_dot_color.a,
+                ],
+            });
+        }
     }
 }
 

--- a/crates/cplp-lobby/Cargo.toml
+++ b/crates/cplp-lobby/Cargo.toml
@@ -25,6 +25,8 @@ jsonwebtoken.workspace = true
 uuid.workspace = true
 axum-extra.workspace = true
 reqwest.workspace = true
+mdns-sd.workspace = true
+hostname = "0.4"
 
 [dev-dependencies]
 axum-test = "18"

--- a/crates/cplp-lobby/src/lib.rs
+++ b/crates/cplp-lobby/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod db;
 pub mod error;
 pub mod jwt;
+pub mod mdns;
 pub mod routes;
 pub mod ws;
 

--- a/crates/cplp-lobby/src/main.rs
+++ b/crates/cplp-lobby/src/main.rs
@@ -1,4 +1,4 @@
-use cplp_lobby::{AppState, LobbyMode, auth, create_router, db, jwt};
+use cplp_lobby::{AppState, LobbyMode, auth, create_router, db, jwt, mdns};
 use tokio::net::TcpListener;
 use tracing_subscriber::EnvFilter;
 
@@ -65,10 +65,26 @@ async fn main() -> anyhow::Result<()> {
 
     let app = create_router(state);
 
-    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
+    let port: u16 = std::env::var("PORT")
+        .unwrap_or_else(|_| "3000".to_string())
+        .parse()
+        .unwrap_or(3000);
     let bind_addr = format!("0.0.0.0:{port}");
     let listener = TcpListener::bind(&bind_addr).await?;
     tracing::info!("cplp-lobby listening on {} (mode: {:?})", bind_addr, lobby_mode);
+
+    // mDNS 広告開始（_advertiser を保持してサーバー終了時に自動 Unregister）
+    let mode_str = match lobby_mode {
+        LobbyMode::Local => "local",
+        LobbyMode::Global => "global",
+    };
+    let _advertiser = match mdns::MdnsAdvertiser::start(port, mode_str) {
+        Ok(adv) => Some(adv),
+        Err(e) => {
+            tracing::warn!("mDNS 広告の開始に失敗（LAN 発見が無効）: {}", e);
+            None
+        }
+    };
 
     axum::serve(listener, app).await?;
 

--- a/crates/cplp-lobby/src/mdns.rs
+++ b/crates/cplp-lobby/src/mdns.rs
@@ -1,0 +1,71 @@
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+
+/// mDNS サービスタイプ（cplp-session::discovery と同じ値）
+const SERVICE_TYPE: &str = "_cplp-lobby._tcp.local.";
+
+/// mDNS 広告のハンドル。Drop 時に自動 Unregister。
+pub struct MdnsAdvertiser {
+    daemon: ServiceDaemon,
+    fullname: String,
+}
+
+impl MdnsAdvertiser {
+    /// mDNS でロビーサーバーを広告開始する
+    pub fn start(port: u16, mode: &str) -> anyhow::Result<Self> {
+        let daemon = ServiceDaemon::new()?;
+
+        let hostname = hostname::get()
+            .unwrap_or_else(|_| "cplp-lobby".into())
+            .to_string_lossy()
+            .to_string();
+
+        let instance_name = format!("cplp-lobby-{}", hostname);
+        let version = env!("CARGO_PKG_VERSION");
+
+        let properties = [("mode", mode), ("version", version)];
+
+        let service_info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &instance_name,
+            &format!("{}.local.", hostname),
+            "",
+            port,
+            &properties[..],
+        )?;
+
+        let fullname = service_info.get_fullname().to_string();
+        daemon.register(service_info)?;
+
+        tracing::info!(
+            "mDNS 広告開始: {} (port: {}, mode: {}, version: {})",
+            fullname,
+            port,
+            mode,
+            version
+        );
+
+        Ok(Self { daemon, fullname })
+    }
+}
+
+impl Drop for MdnsAdvertiser {
+    fn drop(&mut self) {
+        if let Err(e) = self.daemon.unregister(&self.fullname) {
+            tracing::warn!("mDNS 広告解除に失敗: {}", e);
+        } else {
+            tracing::info!("mDNS 広告解除: {}", self.fullname);
+        }
+        self.daemon.shutdown().ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_type_matches_discovery() {
+        // discovery.rs と同じサービスタイプであることを確認
+        assert_eq!(SERVICE_TYPE, "_cplp-lobby._tcp.local.");
+    }
+}

--- a/crates/cplp-session/Cargo.toml
+++ b/crates/cplp-session/Cargo.toml
@@ -19,3 +19,4 @@ reqwest.workspace = true
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
 url.workspace = true
+mdns-sd.workspace = true

--- a/crates/cplp-session/src/discovery.rs
+++ b/crates/cplp-session/src/discovery.rs
@@ -1,0 +1,105 @@
+use std::time::Duration;
+
+use mdns_sd::{ServiceDaemon, ServiceEvent};
+
+/// mDNS サービスタイプ（ロビーとクライアントで共有）
+pub const SERVICE_TYPE: &str = "_cplp-lobby._tcp.local.";
+
+/// mDNS で発見されたロビーサーバー
+#[derive(Debug, Clone)]
+pub struct DiscoveredLobby {
+    /// サービス名（ホスト名ベース）
+    pub name: String,
+    /// 接続用 URL (例: http://192.168.1.10:3000)
+    pub url: String,
+    /// ロビーモード (local / global)
+    pub mode: String,
+    /// サーバーバージョン
+    pub version: String,
+}
+
+/// LAN 内の cplp-lobby サーバーを mDNS で発見する
+pub async fn discover_lobbies(timeout: Duration) -> anyhow::Result<Vec<DiscoveredLobby>> {
+    // mDNS デーモンはブロッキング API のため spawn_blocking で実行
+    let lobbies = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<DiscoveredLobby>> {
+        let mdns = ServiceDaemon::new()?;
+        let receiver = mdns.browse(SERVICE_TYPE)?;
+
+        let mut found: Vec<DiscoveredLobby> = Vec::new();
+        let deadline = std::time::Instant::now() + timeout;
+
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+
+            match receiver.recv_timeout(remaining) {
+                Ok(ServiceEvent::ServiceResolved(info)) => {
+                    let addresses = info.get_addresses();
+                    let Some(addr) = addresses.iter().next() else {
+                        continue;
+                    };
+                    let port = info.get_port();
+                    let url = format!("http://{}:{}", addr, port);
+
+                    let properties = info.get_properties();
+                    let mode = properties
+                        .get_property_val_str("mode")
+                        .unwrap_or("local")
+                        .to_string();
+                    let version = properties
+                        .get_property_val_str("version")
+                        .unwrap_or("unknown")
+                        .to_string();
+
+                    // 重複排除（同一 URL）
+                    if !found.iter().any(|l| l.url == url) {
+                        found.push(DiscoveredLobby {
+                            name: info.get_fullname().to_string(),
+                            url,
+                            mode,
+                            version,
+                        });
+                    }
+                }
+                Ok(_) => {
+                    // SearchStarted, ServiceFound 等は無視
+                }
+                Err(_) => break,
+            }
+        }
+
+        mdns.stop_browse(SERVICE_TYPE).ok();
+        mdns.shutdown().ok();
+        Ok(found)
+    })
+    .await??;
+
+    Ok(lobbies)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_type_is_valid() {
+        assert!(SERVICE_TYPE.starts_with('_'));
+        assert!(SERVICE_TYPE.ends_with(".local."));
+        assert!(SERVICE_TYPE.contains("._tcp"));
+    }
+
+    #[test]
+    fn discovered_lobby_clone() {
+        let lobby = DiscoveredLobby {
+            name: "test._cplp-lobby._tcp.local.".into(),
+            url: "http://192.168.1.10:3000".into(),
+            mode: "local".into(),
+            version: "0.2.0".into(),
+        };
+        let cloned = lobby.clone();
+        assert_eq!(cloned.url, "http://192.168.1.10:3000");
+        assert_eq!(cloned.mode, "local");
+    }
+}

--- a/crates/cplp-session/src/lib.rs
+++ b/crates/cplp-session/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod discovery;
 pub mod lobby;
 pub mod manager;
 pub mod signaling;
 
+pub use discovery::{DiscoveredLobby, discover_lobbies};
 pub use lobby::LobbyClient;
 pub use manager::{SessionManager, SessionState};
 pub use signaling::{LobbyConfig, LobbyEvent, LobbyPeerInfo};


### PR DESCRIPTION
## Summary

- `cplp lobby connect <URL>` — リモートロビーへの接続テスト + グループ一覧表示
- `cplp lobby discover` — LAN 内 mDNS でロビーサーバーを自動発見
- ロビーサーバー側: `_cplp-lobby._tcp.local.` mDNS 広告 (TXT: mode, version)
- HUD: SessionSnapshot にロビー接続状態を追加、ConnectionIndicator にロビーステータス表示

## Changed files

| Crate | File | Change |
|-------|------|--------|
| cplp-session | `discovery.rs` | 新規: mDNS 発見ロジック (`discover_lobbies()`) |
| cplp-lobby | `mdns.rs` | 新規: mDNS 広告 (`MdnsAdvertiser`) |
| cplp-lobby | `main.rs` | mDNS 広告開始を統合 |
| cplp-app | `main.rs` | `Connect` / `Discover` CLI コマンド追加 |
| cplp-hud | `state.rs` | `lobby_url`, `lobby_connected` フィールド追加 |
| cplp-hud | `connection.rs` | ロビー接続ステータス表示 |

## Test plan

- [x] `cargo test --workspace` — 全テスト通過
- [ ] ロビー起動 → `cplp lobby discover` で LAN 発見を確認
- [ ] `cplp lobby connect http://localhost:3000` で接続テスト確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)