### PR TITLE
feat: cplp-gig クレートを追加しシーン/レンダリング分離を実装 (#26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cplp-gig"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "pollster",
+ "tracing",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
 name = "cplp-hud"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/cplp-plug-beat-machine",
     "crates/cplp-plug-looper",
     "crates/cplp-flux",
+    "crates/cplp-gig",
 ]
 resolver = "2"
 

--- a/crates/cplp-gig/Cargo.toml
+++ b/crates/cplp-gig/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cplp-gig"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Gig Scene – 3D ラック/ケーブル UI（visionOS 対応アーキテクチャ）"
+
+[features]
+default = ["wgpu"]
+wgpu = ["dep:wgpu", "dep:winit", "dep:pollster", "dep:bytemuck"]
+
+[dependencies]
+# GPU 非依存
+anyhow.workspace = true
+tracing.workspace = true
+
+# wgpu バックエンド（feature フラグで制御）
+wgpu    = { workspace = true, optional = true }
+winit   = { workspace = true, optional = true }
+pollster = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }

--- a/crates/cplp-gig/src/lib.rs
+++ b/crates/cplp-gig/src/lib.rs
@@ -1,0 +1,24 @@
+//! cplp-gig – Gig Scene（3D ラック/ケーブル UI）
+//!
+//! visionOS 対応を見据え、シーングラフ・メッシュ生成・GPU パイプラインを
+//! 明確に分離したアーキテクチャを採用している。
+//!
+//! # モジュール構成
+//!
+//! | モジュール | 依存 | 責務 |
+//! |------------|------|------|
+//! | `scene` | なし | SceneGraph データ構造 |
+//! | `mesh` | なし（`wgpu` feat で `bytemuck` のみ追加） | メッシュ生成ロジック |
+//! | `render_backend` | なし | `RenderBackend` trait・`DrawCall` |
+//! | `wgpu_backend` | `wgpu` feat | wgpu 実装 |
+
+pub mod mesh;
+pub mod render_backend;
+pub mod scene;
+
+#[cfg(feature = "wgpu")]
+pub mod wgpu_backend;
+
+pub use mesh::{MeshData, Vertex, build_mesh};
+pub use render_backend::{DrawCall, MeshHandle, RenderBackend, build_draw_calls};
+pub use scene::{NodeId, NodeKind, SceneGraph, SceneNode, Transform};

--- a/crates/cplp-gig/src/mesh.rs
+++ b/crates/cplp-gig/src/mesh.rs
@@ -152,41 +152,32 @@ fn cable_mesh(from_pos: [f32; 3], to_pos: [f32; 3]) -> MeshData {
     let dir = [dx / len, dy / len, dz / len];
     let (right, up) = tangent_frame(&dir);
 
-    // ケーブル方向に垂直な 4 方向のオフセット
-    let offsets: [[f32; 2]; 4] = [[r, 0.0], [0.0, r], [-r, 0.0], [0.0, -r]];
+    // ケーブル方向に垂直な 4 方向のオフセット（3D ワールド空間）
+    let offsets: [[f32; 3]; 4] = [
+        [right[0] * r, right[1] * r, right[2] * r],
+        [up[0] * r,    up[1] * r,    up[2] * r   ],
+        [-right[0] * r, -right[1] * r, -right[2] * r],
+        [-up[0] * r,   -up[1] * r,   -up[2] * r  ],
+    ];
 
-    let mut vertices = Vec::with_capacity(8);
-    let mut indices = Vec::with_capacity(24);
+    // フラットシェーディング: 各面に専用の 4 頂点を割り当てる（4面 × 4頂点 = 16頂点）
+    // 面法線 = 隣り合う 2 オフセットの中点方向（面に垂直な外向きベクトル）
+    let mut vertices = Vec::with_capacity(16);
+    let mut indices  = Vec::with_capacity(24);
 
-    // from 側の 4 頂点
-    for &[or, ou] in &offsets {
-        let ox = right[0] * or + up[0] * ou;
-        let oy = right[1] * or + up[1] * ou;
-        let oz = right[2] * or + up[2] * ou;
-        vertices.push(Vertex {
-            position: [from_pos[0] + ox, from_pos[1] + oy, from_pos[2] + oz],
-            normal: normalize([ox, oy, oz]),
-            uv: [0.0, 0.0],
-            color,
-        });
-    }
-    // to 側の 4 頂点
-    for &[or, ou] in &offsets {
-        let ox = right[0] * or + up[0] * ou;
-        let oy = right[1] * or + up[1] * ou;
-        let oz = right[2] * or + up[2] * ou;
-        vertices.push(Vertex {
-            position: [to_pos[0] + ox, to_pos[1] + oy, to_pos[2] + oz],
-            normal: normalize([ox, oy, oz]),
-            uv: [0.0, 1.0],
-            color,
-        });
-    }
-
-    for i in 0u32..4 {
+    for i in 0..4usize {
         let next = (i + 1) % 4;
-        let (t0, t1, b0, b1) = (i, next, i + 4, next + 4);
-        indices.extend_from_slice(&[t0, b0, b1, t0, b1, t1]);
+        let o0 = offsets[i];
+        let o1 = offsets[next];
+        let normal = normalize([o0[0] + o1[0], o0[1] + o1[1], o0[2] + o1[2]]);
+
+        let base = (i * 4) as u32;
+        vertices.push(Vertex { position: [from_pos[0]+o0[0], from_pos[1]+o0[1], from_pos[2]+o0[2]], normal, uv: [0.0, 0.0], color });
+        vertices.push(Vertex { position: [from_pos[0]+o1[0], from_pos[1]+o1[1], from_pos[2]+o1[2]], normal, uv: [1.0, 0.0], color });
+        vertices.push(Vertex { position: [  to_pos[0]+o1[0],   to_pos[1]+o1[1],   to_pos[2]+o1[2]], normal, uv: [1.0, 1.0], color });
+        vertices.push(Vertex { position: [  to_pos[0]+o0[0],   to_pos[1]+o0[1],   to_pos[2]+o0[2]], normal, uv: [0.0, 1.0], color });
+
+        indices.extend_from_slice(&[base, base+1, base+2, base, base+2, base+3]);
     }
 
     MeshData { vertices, indices }
@@ -236,7 +227,7 @@ fn cross(a: &[f32; 3], b: &[f32; 3]) -> [f32; 3] {
 
 fn normalize(v: [f32; 3]) -> [f32; 3] {
     let len = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
-    if len < 1e-6 { v } else { [v[0] / len, v[1] / len, v[2] / len] }
+    if len < 1e-6 { [0.0, 1.0, 0.0] } else { [v[0] / len, v[1] / len, v[2] / len] }
 }
 
 #[cfg(test)]
@@ -293,8 +284,8 @@ mod tests {
             transform: Transform::default(),
         };
         let mesh = build_mesh(&cable_node, &graph);
-        assert_eq!(mesh.vertex_count(), 8);
-        assert_eq!(mesh.index_count(), 24);
+        assert_eq!(mesh.vertex_count(), 16); // 4面 × 4頂点（フラットシェーディング）
+        assert_eq!(mesh.index_count(), 24);  // 4面 × 2三角形 × 3インデックス
         // from (x=0) から to (x=1) までスパンしているか確認
         let min_x = mesh.vertices.iter().map(|v| v.position[0]).fold(f32::INFINITY, f32::min);
         let max_x = mesh.vertices.iter().map(|v| v.position[0]).fold(f32::NEG_INFINITY, f32::max);

--- a/crates/cplp-gig/src/mesh.rs
+++ b/crates/cplp-gig/src/mesh.rs
@@ -4,7 +4,7 @@
 //! GPU バッファへのアップロードは行わない。純粋関数で実装されており、
 //! GPU デバイスなしで単体テストが可能。
 
-use crate::scene::{NodeKind, SceneNode, Transform};
+use crate::scene::{NodeId, NodeKind, SceneGraph, SceneNode, Transform};
 
 /// 1 頂点のデータ。
 ///
@@ -48,15 +48,26 @@ impl MeshData {
 
 /// SceneNode から対応する MeshData を生成する。
 ///
+/// `Cable` ノードは `graph` から接続先ノードの位置を解決するため、
+/// `SceneGraph` への参照が必要。他のノード種別は `graph` を使用しない。
 /// 未対応の NodeKind には空の MeshData を返す。
-pub fn build_mesh(node: &SceneNode) -> MeshData {
+pub fn build_mesh(node: &SceneNode, graph: &SceneGraph) -> MeshData {
     match &node.kind {
         NodeKind::RackUnit { active, rack_units, .. } => {
             rack_unit_mesh(&node.transform, *active, *rack_units)
         }
-        NodeKind::Cable { .. } => cable_mesh(&node.transform),
+        NodeKind::Cable { from, to } => {
+            let from_pos = resolve_position(*from, graph);
+            let to_pos = resolve_position(*to, graph);
+            cable_mesh(from_pos, to_pos)
+        }
         NodeKind::Background => background_mesh(),
     }
+}
+
+/// NodeId からノードの位置を解決する。ノードが存在しない場合は原点を返す。
+fn resolve_position(id: NodeId, graph: &SceneGraph) -> [f32; 3] {
+    graph.get(id).map(|n| n.transform.position).unwrap_or([0.0, 0.0, 0.0])
 }
 
 /// ラックユニット（直方体）のメッシュを生成する。
@@ -74,15 +85,12 @@ fn rack_unit_mesh(transform: &Transform, active: bool, rack_units: u32) -> MeshD
     };
 
     let [px, py, pz] = transform.position;
-
-    // 前面・後面・左右・上下の 6 面（各 4 頂点 × 6 面 = 24 頂点）
     let hw = w / 2.0;
     let hh = h / 2.0;
     let hd = d / 2.0;
 
     #[rustfmt::skip]
     let face_data: &[([f32; 3], [f32; 3])] = &[
-        // (法線, 面の中心オフセット) – 各面の 4 頂点を展開する基底として使用
         ([0.0,  0.0,  1.0], [0.0, 0.0,  hd]), // 前
         ([0.0,  0.0, -1.0], [0.0, 0.0, -hd]), // 後
         ([-1.0, 0.0,  0.0], [-hw, 0.0, 0.0]), // 左
@@ -95,11 +103,8 @@ fn rack_unit_mesh(transform: &Transform, active: bool, rack_units: u32) -> MeshD
     let mut indices = Vec::with_capacity(36);
 
     for (face_idx, (normal, center)) in face_data.iter().enumerate() {
-        // 面に平行な 2 軸を法線から導出（簡易版）
         let (right, up) = tangent_frame(normal);
-
-        let half_extents = face_half_extents(normal, hw, hh, hd);
-        let (right_e, up_e) = half_extents;
+        let (right_e, up_e) = face_half_extents(normal, hw, hh, hd);
 
         let corners = [
             [-right_e, -up_e],
@@ -110,7 +115,7 @@ fn rack_unit_mesh(transform: &Transform, active: bool, rack_units: u32) -> MeshD
         let uvs = [[0.0f32, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]];
 
         let base = (face_idx * 4) as u32;
-        for (i, ([ru, uu], uv)) in corners.iter().zip(uvs.iter()).enumerate() {
+        for ([ru, uu], uv) in corners.iter().zip(uvs.iter()) {
             vertices.push(Vertex {
                 position: [
                     px + center[0] + right[0] * ru + up[0] * uu,
@@ -121,7 +126,6 @@ fn rack_unit_mesh(transform: &Transform, active: bool, rack_units: u32) -> MeshD
                 uv: *uv,
                 color,
             });
-            let _ = i; // suppress unused warning
         }
         indices.extend_from_slice(&[base, base+1, base+2, base, base+2, base+3]);
     }
@@ -129,32 +133,51 @@ fn rack_unit_mesh(transform: &Transform, active: bool, rack_units: u32) -> MeshD
     MeshData { vertices, indices }
 }
 
-/// ケーブル（細い円柱）のメッシュを生成する（簡易版: 4 辺柱）。
-fn cable_mesh(transform: &Transform) -> MeshData {
+/// ケーブル（細い4辺柱）のメッシュを2点間で生成する。
+///
+/// `from_pos` から `to_pos` へ延びるケーブルを表す。
+/// 2点が同一の場合（縮退ケーブル）は空のメッシュを返す。
+fn cable_mesh(from_pos: [f32; 3], to_pos: [f32; 3]) -> MeshData {
+    let dx = to_pos[0] - from_pos[0];
+    let dy = to_pos[1] - from_pos[1];
+    let dz = to_pos[2] - from_pos[2];
+    let len = (dx * dx + dy * dy + dz * dz).sqrt();
+    if len < 1e-6 {
+        return MeshData::new(); // 縮退ケーブル: メッシュなし
+    }
+
     let r = 0.005f32; // 半径 5 mm
-    let [px, py, pz] = transform.position;
     let color = [0.8, 0.5, 0.1, 1.0];
 
-    // 単純な 4 角柱（上端 → 下端）
-    let top_y = py + 0.5;
-    let bot_y = py - 0.5;
-    let offsets = [[r, 0.0], [0.0, r], [-r, 0.0], [0.0, -r]];
+    let dir = [dx / len, dy / len, dz / len];
+    let (right, up) = tangent_frame(&dir);
+
+    // ケーブル方向に垂直な 4 方向のオフセット
+    let offsets: [[f32; 2]; 4] = [[r, 0.0], [0.0, r], [-r, 0.0], [0.0, -r]];
 
     let mut vertices = Vec::with_capacity(8);
     let mut indices = Vec::with_capacity(24);
 
-    for &[ox, oz] in &offsets {
+    // from 側の 4 頂点
+    for &[or, ou] in &offsets {
+        let ox = right[0] * or + up[0] * ou;
+        let oy = right[1] * or + up[1] * ou;
+        let oz = right[2] * or + up[2] * ou;
         vertices.push(Vertex {
-            position: [px + ox, top_y, pz + oz],
-            normal: [ox / r, 0.0, oz / r],
+            position: [from_pos[0] + ox, from_pos[1] + oy, from_pos[2] + oz],
+            normal: normalize([ox, oy, oz]),
             uv: [0.0, 0.0],
             color,
         });
     }
-    for &[ox, oz] in &offsets {
+    // to 側の 4 頂点
+    for &[or, ou] in &offsets {
+        let ox = right[0] * or + up[0] * ou;
+        let oy = right[1] * or + up[1] * ou;
+        let oz = right[2] * or + up[2] * ou;
         vertices.push(Vertex {
-            position: [px + ox, bot_y, pz + oz],
-            normal: [ox / r, 0.0, oz / r],
+            position: [to_pos[0] + ox, to_pos[1] + oy, to_pos[2] + oz],
+            normal: normalize([ox, oy, oz]),
             uv: [0.0, 1.0],
             color,
         });
@@ -162,10 +185,7 @@ fn cable_mesh(transform: &Transform) -> MeshData {
 
     for i in 0u32..4 {
         let next = (i + 1) % 4;
-        let t0 = i;
-        let t1 = next;
-        let b0 = i + 4;
-        let b1 = next + 4;
+        let (t0, t1, b0, b1) = (i, next, i + 4, next + 4);
         indices.extend_from_slice(&[t0, b0, b1, t0, b1, t1]);
     }
 
@@ -194,8 +214,7 @@ fn background_mesh() -> MeshData {
 /// 法線から接線フレーム (right, up) を導出する（グラム=シュミット）。
 fn tangent_frame(normal: &[f32; 3]) -> ([f32; 3], [f32; 3]) {
     let up_hint = if normal[1].abs() < 0.9 { [0.0f32, 1.0, 0.0] } else { [1.0, 0.0, 0.0] };
-    let right = cross(normal, &up_hint);
-    let right = normalize(right);
+    let right = normalize(cross(normal, &up_hint));
     let up = cross(&right, normal);
     (right, up)
 }
@@ -223,7 +242,7 @@ fn normalize(v: [f32; 3]) -> [f32; 3] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::scene::{NodeKind, SceneNode, NodeId, Transform};
+    use crate::scene::{NodeKind, NodeId, SceneGraph, SceneNode, Transform};
 
     fn make_node(kind: NodeKind) -> SceneNode {
         SceneNode { id: NodeId(0), kind, transform: Transform::default() }
@@ -231,35 +250,68 @@ mod tests {
 
     #[test]
     fn rack_unit_mesh_vertex_count() {
+        let graph = SceneGraph::new();
         let node = make_node(NodeKind::RackUnit {
             name: "Test".into(),
             active: false,
             rack_units: 1,
         });
-        let mesh = build_mesh(&node);
-        // 6 面 × 4 頂点
-        assert_eq!(mesh.vertex_count(), 24);
-        // 6 面 × 2 三角形 × 3 インデックス
-        assert_eq!(mesh.index_count(), 36);
+        let mesh = build_mesh(&node, &graph);
+        assert_eq!(mesh.vertex_count(), 24); // 6 面 × 4 頂点
+        assert_eq!(mesh.index_count(), 36);  // 6 面 × 2 三角形 × 3 インデックス
     }
 
     #[test]
     fn background_mesh_valid() {
+        let graph = SceneGraph::new();
         let node = make_node(NodeKind::Background);
-        let mesh = build_mesh(&node);
+        let mesh = build_mesh(&node, &graph);
         assert_eq!(mesh.vertex_count(), 4);
         assert_eq!(mesh.index_count(), 6);
     }
 
     #[test]
     fn active_rack_unit_has_green_color() {
+        let graph = SceneGraph::new();
         let node = make_node(NodeKind::RackUnit {
             name: "Synth".into(),
             active: true,
             rack_units: 2,
         });
-        let mesh = build_mesh(&node);
-        // 最初の頂点が「アクティブ緑」
+        let mesh = build_mesh(&node, &graph);
         assert!(mesh.vertices[0].color[1] > 0.8);
+    }
+
+    #[test]
+    fn cable_mesh_connects_from_to_positions() {
+        let mut graph = SceneGraph::new();
+        let a = graph.add_node(NodeKind::Background, Transform::at([0.0, 0.0, 0.0]));
+        let b = graph.add_node(NodeKind::Background, Transform::at([1.0, 0.0, 0.0]));
+        let cable_node = SceneNode {
+            id: NodeId(99),
+            kind: NodeKind::Cable { from: a, to: b },
+            transform: Transform::default(),
+        };
+        let mesh = build_mesh(&cable_node, &graph);
+        assert_eq!(mesh.vertex_count(), 8);
+        assert_eq!(mesh.index_count(), 24);
+        // from (x=0) から to (x=1) までスパンしているか確認
+        let min_x = mesh.vertices.iter().map(|v| v.position[0]).fold(f32::INFINITY, f32::min);
+        let max_x = mesh.vertices.iter().map(|v| v.position[0]).fold(f32::NEG_INFINITY, f32::max);
+        assert!(max_x - min_x > 0.9);
+    }
+
+    #[test]
+    fn cable_mesh_degenerate_returns_empty() {
+        let mut graph = SceneGraph::new();
+        let a = graph.add_node(NodeKind::Background, Transform::at([1.0, 0.0, 0.0]));
+        let b = graph.add_node(NodeKind::Background, Transform::at([1.0, 0.0, 0.0])); // 同座標
+        let cable_node = SceneNode {
+            id: NodeId(99),
+            kind: NodeKind::Cable { from: a, to: b },
+            transform: Transform::default(),
+        };
+        let mesh = build_mesh(&cable_node, &graph);
+        assert_eq!(mesh.vertex_count(), 0);
     }
 }

--- a/crates/cplp-gig/src/mesh.rs
+++ b/crates/cplp-gig/src/mesh.rs
@@ -1,0 +1,265 @@
+//! メッシュ生成ロジック – プラットフォーム非依存
+//!
+//! SceneNode の種別から `MeshData`（頂点・インデックス列）を生成する。
+//! GPU バッファへのアップロードは行わない。純粋関数で実装されており、
+//! GPU デバイスなしで単体テストが可能。
+
+use crate::scene::{NodeKind, SceneNode, Transform};
+
+/// 1 頂点のデータ。
+///
+/// `bytemuck::Pod` / `Zeroable` は `wgpu` feature が有効なときのみ derive する。
+/// これにより GPU バッファへの zero-copy 書き込みが可能になる。
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "wgpu", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[repr(C)]
+pub struct Vertex {
+    pub position: [f32; 3],
+    pub normal: [f32; 3],
+    pub uv: [f32; 2],
+    pub color: [f32; 4],
+}
+
+/// 1 メッシュのジオメトリデータ。GPU への依存なし。
+#[derive(Debug, Clone, Default)]
+pub struct MeshData {
+    pub vertices: Vec<Vertex>,
+    pub indices: Vec<u32>,
+}
+
+impl MeshData {
+    /// 新しい空の MeshData を返す。
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 頂点数を返す。
+    pub fn vertex_count(&self) -> usize {
+        self.vertices.len()
+    }
+
+    /// インデックス数（= 三角形数 × 3）を返す。
+    pub fn index_count(&self) -> usize {
+        self.indices.len()
+    }
+}
+
+// ── 生成関数 ──────────────────────────────────────────────────────────────────
+
+/// SceneNode から対応する MeshData を生成する。
+///
+/// 未対応の NodeKind には空の MeshData を返す。
+pub fn build_mesh(node: &SceneNode) -> MeshData {
+    match &node.kind {
+        NodeKind::RackUnit { active, rack_units, .. } => {
+            rack_unit_mesh(&node.transform, *active, *rack_units)
+        }
+        NodeKind::Cable { .. } => cable_mesh(&node.transform),
+        NodeKind::Background => background_mesh(),
+    }
+}
+
+/// ラックユニット（直方体）のメッシュを生成する。
+///
+/// 高さは `rack_units × 0.044 m`（19 インチラック 1U = 44.45 mm）。
+fn rack_unit_mesh(transform: &Transform, active: bool, rack_units: u32) -> MeshData {
+    let w = 0.48; // 19 インチラック幅
+    let h = 0.04445 * rack_units as f32;
+    let d = 0.30; // 奥行き 300 mm
+
+    let color = if active {
+        [0.2, 0.9, 0.4, 1.0] // アクティブ: 緑
+    } else {
+        [0.3, 0.3, 0.35, 1.0] // 非アクティブ: グレー
+    };
+
+    let [px, py, pz] = transform.position;
+
+    // 前面・後面・左右・上下の 6 面（各 4 頂点 × 6 面 = 24 頂点）
+    let hw = w / 2.0;
+    let hh = h / 2.0;
+    let hd = d / 2.0;
+
+    #[rustfmt::skip]
+    let face_data: &[([f32; 3], [f32; 3])] = &[
+        // (法線, 面の中心オフセット) – 各面の 4 頂点を展開する基底として使用
+        ([0.0,  0.0,  1.0], [0.0, 0.0,  hd]), // 前
+        ([0.0,  0.0, -1.0], [0.0, 0.0, -hd]), // 後
+        ([-1.0, 0.0,  0.0], [-hw, 0.0, 0.0]), // 左
+        ([1.0,  0.0,  0.0], [ hw, 0.0, 0.0]), // 右
+        ([0.0,  1.0,  0.0], [0.0,  hh, 0.0]), // 上
+        ([0.0, -1.0,  0.0], [0.0, -hh, 0.0]), // 下
+    ];
+
+    let mut vertices = Vec::with_capacity(24);
+    let mut indices = Vec::with_capacity(36);
+
+    for (face_idx, (normal, center)) in face_data.iter().enumerate() {
+        // 面に平行な 2 軸を法線から導出（簡易版）
+        let (right, up) = tangent_frame(normal);
+
+        let half_extents = face_half_extents(normal, hw, hh, hd);
+        let (right_e, up_e) = half_extents;
+
+        let corners = [
+            [-right_e, -up_e],
+            [ right_e, -up_e],
+            [ right_e,  up_e],
+            [-right_e,  up_e],
+        ];
+        let uvs = [[0.0f32, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]];
+
+        let base = (face_idx * 4) as u32;
+        for (i, ([ru, uu], uv)) in corners.iter().zip(uvs.iter()).enumerate() {
+            vertices.push(Vertex {
+                position: [
+                    px + center[0] + right[0] * ru + up[0] * uu,
+                    py + center[1] + right[1] * ru + up[1] * uu,
+                    pz + center[2] + right[2] * ru + up[2] * uu,
+                ],
+                normal: *normal,
+                uv: *uv,
+                color,
+            });
+            let _ = i; // suppress unused warning
+        }
+        indices.extend_from_slice(&[base, base+1, base+2, base, base+2, base+3]);
+    }
+
+    MeshData { vertices, indices }
+}
+
+/// ケーブル（細い円柱）のメッシュを生成する（簡易版: 4 辺柱）。
+fn cable_mesh(transform: &Transform) -> MeshData {
+    let r = 0.005f32; // 半径 5 mm
+    let [px, py, pz] = transform.position;
+    let color = [0.8, 0.5, 0.1, 1.0];
+
+    // 単純な 4 角柱（上端 → 下端）
+    let top_y = py + 0.5;
+    let bot_y = py - 0.5;
+    let offsets = [[r, 0.0], [0.0, r], [-r, 0.0], [0.0, -r]];
+
+    let mut vertices = Vec::with_capacity(8);
+    let mut indices = Vec::with_capacity(24);
+
+    for &[ox, oz] in &offsets {
+        vertices.push(Vertex {
+            position: [px + ox, top_y, pz + oz],
+            normal: [ox / r, 0.0, oz / r],
+            uv: [0.0, 0.0],
+            color,
+        });
+    }
+    for &[ox, oz] in &offsets {
+        vertices.push(Vertex {
+            position: [px + ox, bot_y, pz + oz],
+            normal: [ox / r, 0.0, oz / r],
+            uv: [0.0, 1.0],
+            color,
+        });
+    }
+
+    for i in 0u32..4 {
+        let next = (i + 1) % 4;
+        let t0 = i;
+        let t1 = next;
+        let b0 = i + 4;
+        let b1 = next + 4;
+        indices.extend_from_slice(&[t0, b0, b1, t0, b1, t1]);
+    }
+
+    MeshData { vertices, indices }
+}
+
+/// 背景プレーン（XZ 平面上の単純な四角形）を生成する。
+fn background_mesh() -> MeshData {
+    let size = 5.0f32;
+    let color = [0.05, 0.05, 0.08, 1.0];
+    let normal = [0.0f32, 1.0, 0.0];
+
+    let vertices = vec![
+        Vertex { position: [-size, 0.0, -size], normal, uv: [0.0, 0.0], color },
+        Vertex { position: [ size, 0.0, -size], normal, uv: [1.0, 0.0], color },
+        Vertex { position: [ size, 0.0,  size], normal, uv: [1.0, 1.0], color },
+        Vertex { position: [-size, 0.0,  size], normal, uv: [0.0, 1.0], color },
+    ];
+    let indices = vec![0, 1, 2, 0, 2, 3];
+
+    MeshData { vertices, indices }
+}
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────────
+
+/// 法線から接線フレーム (right, up) を導出する（グラム=シュミット）。
+fn tangent_frame(normal: &[f32; 3]) -> ([f32; 3], [f32; 3]) {
+    let up_hint = if normal[1].abs() < 0.9 { [0.0f32, 1.0, 0.0] } else { [1.0, 0.0, 0.0] };
+    let right = cross(normal, &up_hint);
+    let right = normalize(right);
+    let up = cross(&right, normal);
+    (right, up)
+}
+
+/// 各面のハーフエクステント (right_e, up_e) を返す。
+fn face_half_extents(normal: &[f32; 3], hw: f32, hh: f32, hd: f32) -> (f32, f32) {
+    if normal[2].abs() > 0.5 { (hw, hh) }      // 前後面
+    else if normal[0].abs() > 0.5 { (hd, hh) } // 左右面
+    else { (hw, hd) }                           // 上下面
+}
+
+fn cross(a: &[f32; 3], b: &[f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn normalize(v: [f32; 3]) -> [f32; 3] {
+    let len = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+    if len < 1e-6 { v } else { [v[0] / len, v[1] / len, v[2] / len] }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scene::{NodeKind, SceneNode, NodeId, Transform};
+
+    fn make_node(kind: NodeKind) -> SceneNode {
+        SceneNode { id: NodeId(0), kind, transform: Transform::default() }
+    }
+
+    #[test]
+    fn rack_unit_mesh_vertex_count() {
+        let node = make_node(NodeKind::RackUnit {
+            name: "Test".into(),
+            active: false,
+            rack_units: 1,
+        });
+        let mesh = build_mesh(&node);
+        // 6 面 × 4 頂点
+        assert_eq!(mesh.vertex_count(), 24);
+        // 6 面 × 2 三角形 × 3 インデックス
+        assert_eq!(mesh.index_count(), 36);
+    }
+
+    #[test]
+    fn background_mesh_valid() {
+        let node = make_node(NodeKind::Background);
+        let mesh = build_mesh(&node);
+        assert_eq!(mesh.vertex_count(), 4);
+        assert_eq!(mesh.index_count(), 6);
+    }
+
+    #[test]
+    fn active_rack_unit_has_green_color() {
+        let node = make_node(NodeKind::RackUnit {
+            name: "Synth".into(),
+            active: true,
+            rack_units: 2,
+        });
+        let mesh = build_mesh(&node);
+        // 最初の頂点が「アクティブ緑」
+        assert!(mesh.vertices[0].color[1] > 0.8);
+    }
+}

--- a/crates/cplp-gig/src/render_backend.rs
+++ b/crates/cplp-gig/src/render_backend.rs
@@ -1,0 +1,114 @@
+//! RenderBackend trait – プラットフォーム非依存の描画インターフェース
+//!
+//! wgpu・Metal・RealityKit など、具体的な GPU バックエンドを抽象化する。
+//! visionOS 向けの実装はこのトレイトを実装するだけで cplp-gig の他のコードを
+//! 変更せずに動作させることができる。
+
+use crate::mesh::MeshData;
+
+/// GPU 上にアップロード済みのメッシュを参照する不透明なハンドル。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MeshHandle(pub(crate) u32);
+
+/// 1 フレームで発行する描画命令。
+#[derive(Debug, Clone)]
+pub struct DrawCall {
+    /// 描画するメッシュへのハンドル
+    pub mesh: MeshHandle,
+    /// モデル行列（列優先 4×4）
+    pub transform: [[f32; 4]; 4],
+}
+
+impl DrawCall {
+    /// 単位行列のトランスフォームで DrawCall を作成する。
+    pub fn identity(mesh: MeshHandle) -> Self {
+        Self {
+            mesh,
+            transform: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        }
+    }
+}
+
+/// 描画バックエンドの抽象トレイト。
+///
+/// バックエンドの実装者は次の責務を持つ:
+/// - `upload_mesh`: CPU 側の `MeshData` を GPU メモリへ転送し `MeshHandle` を返す
+/// - `free_mesh`: アップロード済みメッシュを解放する
+/// - `submit_frame`: 1 フレーム分の `DrawCall` リストを GPU に送信し描画する
+/// - `resize`: ウィンドウ/ビューポートのサイズ変更に対応する
+pub trait RenderBackend {
+    /// `MeshData` を GPU へアップロードし、ハンドルを返す。
+    fn upload_mesh(&mut self, mesh: &MeshData) -> MeshHandle;
+
+    /// アップロード済みメッシュを GPU メモリから解放する。
+    fn free_mesh(&mut self, handle: MeshHandle);
+
+    /// 1 フレーム分の描画コマンドを GPU に送信する。
+    ///
+    /// `draw_calls` は上から順に描画される（後のものが手前に表示）。
+    fn submit_frame(&mut self, draw_calls: &[DrawCall]);
+
+    /// ビューポートサイズを更新する。
+    fn resize(&mut self, width: u32, height: u32);
+}
+
+/// SceneGraph 全体の描画コマンドを構築するヘルパー。
+///
+/// `upload_mesh` で事前にアップロードされたハンドルと SceneNode のリストを受け取り、
+/// `DrawCall` のリストを生成する。
+pub fn build_draw_calls(
+    node_handles: &[(crate::scene::NodeId, MeshHandle)],
+    graph: &crate::scene::SceneGraph,
+) -> Vec<DrawCall> {
+    let mut draw_calls = Vec::with_capacity(node_handles.len());
+
+    for (node_id, mesh_handle) in node_handles {
+        if let Some(node) = graph.nodes().iter().find(|n| n.id == *node_id) {
+            let t = &node.transform;
+            // 簡易モデル行列（回転なし・スケールなし版）
+            // 将来: 四元数からの行列変換を追加
+            let transform = [
+                [t.scale[0], 0.0, 0.0, 0.0],
+                [0.0, t.scale[1], 0.0, 0.0],
+                [0.0, 0.0, t.scale[2], 0.0],
+                [t.position[0], t.position[1], t.position[2], 1.0],
+            ];
+            draw_calls.push(DrawCall { mesh: *mesh_handle, transform });
+        }
+    }
+
+    draw_calls
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scene::{NodeKind, SceneGraph, Transform};
+
+    #[test]
+    fn build_draw_calls_maps_node_to_mesh() {
+        let mut graph = SceneGraph::new();
+        let id = graph.add_node(NodeKind::Background, Transform::at([1.0, 2.0, 3.0]));
+
+        let handle = MeshHandle(42);
+        let calls = build_draw_calls(&[(id, handle)], &graph);
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].mesh, handle);
+        // 平行移動列が正しく設定されているか
+        assert_eq!(calls[0].transform[3], [1.0, 2.0, 3.0, 1.0]);
+    }
+
+    #[test]
+    fn build_draw_calls_skips_missing_nodes() {
+        let graph = SceneGraph::new();
+        let handle = MeshHandle(0);
+        let calls = build_draw_calls(&[(crate::scene::NodeId(99), handle)], &graph);
+        assert!(calls.is_empty());
+    }
+}

--- a/crates/cplp-gig/src/render_backend.rs
+++ b/crates/cplp-gig/src/render_backend.rs
@@ -16,6 +16,18 @@ pub struct DrawCall {
     /// 描画するメッシュへのハンドル
     pub mesh: MeshHandle,
     /// モデル行列（列優先 4×4）
+    ///
+    /// `transform[col][row]` の順で要素を格納する列優先レイアウト。
+    /// WGSL の `mat4x4<f32>` と同じメモリ配置であり、バイト列にキャストして
+    /// そのままシェーダーへ転送できる。
+    ///
+    /// 例: 平行移動 (tx, ty, tz) のみの行列:
+    /// ```text
+    /// transform[0] = [1, 0, 0, 0]  // 列 0
+    /// transform[1] = [0, 1, 0, 0]  // 列 1
+    /// transform[2] = [0, 0, 1, 0]  // 列 2
+    /// transform[3] = [tx, ty, tz, 1] // 列 3（平行移動列）
+    /// ```
     pub transform: [[f32; 4]; 4],
 }
 
@@ -61,28 +73,29 @@ pub trait RenderBackend {
 ///
 /// `upload_mesh` で事前にアップロードされたハンドルと SceneNode のリストを受け取り、
 /// `DrawCall` のリストを生成する。
+/// `SceneGraph::get` による O(1) 検索を使用するため、全体計算量は O(M)。
 pub fn build_draw_calls(
     node_handles: &[(crate::scene::NodeId, MeshHandle)],
     graph: &crate::scene::SceneGraph,
 ) -> Vec<DrawCall> {
-    let mut draw_calls = Vec::with_capacity(node_handles.len());
-
-    for (node_id, mesh_handle) in node_handles {
-        if let Some(node) = graph.nodes().iter().find(|n| n.id == *node_id) {
-            let t = &node.transform;
-            // 簡易モデル行列（回転なし・スケールなし版）
-            // 将来: 四元数からの行列変換を追加
-            let transform = [
-                [t.scale[0], 0.0, 0.0, 0.0],
-                [0.0, t.scale[1], 0.0, 0.0],
-                [0.0, 0.0, t.scale[2], 0.0],
-                [t.position[0], t.position[1], t.position[2], 1.0],
-            ];
-            draw_calls.push(DrawCall { mesh: *mesh_handle, transform });
-        }
-    }
-
-    draw_calls
+    node_handles
+        .iter()
+        .filter_map(|(node_id, mesh_handle)| {
+            graph.get(*node_id).map(|node| {
+                let t = &node.transform;
+                // 列優先モデル行列（スケール + 平行移動）。
+                // transform[col][row] の順。列 3 が平行移動列。
+                // 将来: 四元数からの回転行列を乗算する。
+                let transform = [
+                    [t.scale[0], 0.0, 0.0, 0.0], // 列 0
+                    [0.0, t.scale[1], 0.0, 0.0],  // 列 1
+                    [0.0, 0.0, t.scale[2], 0.0],  // 列 2
+                    [t.position[0], t.position[1], t.position[2], 1.0], // 列 3
+                ];
+                DrawCall { mesh: *mesh_handle, transform }
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -100,7 +113,7 @@ mod tests {
 
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].mesh, handle);
-        // 平行移動列が正しく設定されているか
+        // 列 3 が平行移動列: transform[3] = [tx, ty, tz, 1]
         assert_eq!(calls[0].transform[3], [1.0, 2.0, 3.0, 1.0]);
     }
 

--- a/crates/cplp-gig/src/scene.rs
+++ b/crates/cplp-gig/src/scene.rs
@@ -3,6 +3,8 @@
 //! GPU への依存を一切持たない。Clone・Debug を実装し、
 //! スナップショットテストや状態保存が容易。
 
+use std::collections::HashMap;
+
 /// ノードを一意に識別する ID。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(pub u32);
@@ -69,11 +71,23 @@ pub struct SceneNode {
 /// シーン全体を保持するグラフ。
 ///
 /// GPU オブジェクトへの参照を持たない。
-/// バックエンドへの送信前に `build_draw_calls` でジオメトリ情報へ変換する。
-#[derive(Debug, Clone, Default)]
+/// `lookup` により NodeId から O(1) でノードを取得できる。
+#[derive(Debug, Clone)]
 pub struct SceneGraph {
     nodes: Vec<SceneNode>,
+    /// NodeId → nodes 配列インデックス のマップ（O(1) 検索用）
+    lookup: HashMap<NodeId, usize>,
     next_id: u32,
+}
+
+impl Default for SceneGraph {
+    fn default() -> Self {
+        Self {
+            nodes: Vec::new(),
+            lookup: HashMap::new(),
+            next_id: 0,
+        }
+    }
 }
 
 impl SceneGraph {
@@ -85,18 +99,35 @@ impl SceneGraph {
     pub fn add_node(&mut self, kind: NodeKind, transform: Transform) -> NodeId {
         let id = NodeId(self.next_id);
         self.next_id += 1;
+        let idx = self.nodes.len();
         self.nodes.push(SceneNode { id, kind, transform });
+        self.lookup.insert(id, idx);
         id
     }
 
-    /// 指定 ID のノードを削除する。存在しない場合は何もしない。
+    /// 指定 ID のノードを O(1) で削除する。存在しない場合は何もしない。
+    ///
+    /// 内部的に `swap_remove` を使うため、削除後にノードの順序が変わる可能性がある。
     pub fn remove_node(&mut self, id: NodeId) {
-        self.nodes.retain(|n| n.id != id);
+        if let Some(&idx) = self.lookup.get(&id) {
+            self.nodes.swap_remove(idx);
+            self.lookup.remove(&id);
+            // swap_remove で末尾ノードが idx に移動した場合、そのインデックスを更新する
+            if idx < self.nodes.len() {
+                let moved_id = self.nodes[idx].id;
+                self.lookup.insert(moved_id, idx);
+            }
+        }
     }
 
-    /// 指定 ID のノードへの可変参照を返す。
+    /// 指定 ID のノードへの参照を O(1) で返す。
+    pub fn get(&self, id: NodeId) -> Option<&SceneNode> {
+        self.lookup.get(&id).map(|&i| &self.nodes[i])
+    }
+
+    /// 指定 ID のノードへの可変参照を O(1) で返す。
     pub fn get_mut(&mut self, id: NodeId) -> Option<&mut SceneNode> {
-        self.nodes.iter_mut().find(|n| n.id == id)
+        self.lookup.get(&id).map(|&i| &mut self.nodes[i])
     }
 
     /// 全ノードのスライスを返す。
@@ -107,6 +138,7 @@ impl SceneGraph {
     /// 全ノードをクリアする。
     pub fn clear(&mut self) {
         self.nodes.clear();
+        self.lookup.clear();
     }
 }
 
@@ -128,6 +160,29 @@ mod tests {
         assert_eq!(graph.nodes().len(), 1);
         graph.remove_node(id);
         assert!(graph.nodes().is_empty());
+        assert!(graph.get(id).is_none());
+    }
+
+    #[test]
+    fn get_returns_correct_node() {
+        let mut graph = SceneGraph::new();
+        let id = graph.add_node(NodeKind::Background, Transform::at([1.0, 2.0, 3.0]));
+        let node = graph.get(id).unwrap();
+        assert_eq!(node.transform.position, [1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn remove_updates_lookup_for_swapped_node() {
+        let mut graph = SceneGraph::new();
+        let a = graph.add_node(NodeKind::Background, Transform::default());
+        let b = graph.add_node(NodeKind::Background, Transform::default());
+        let c = graph.add_node(NodeKind::Background, Transform::default());
+
+        // a を削除すると c が index 0 に移動する
+        graph.remove_node(a);
+        assert!(graph.get(a).is_none());
+        assert!(graph.get(b).is_some());
+        assert!(graph.get(c).is_some());
     }
 
     #[test]
@@ -139,7 +194,7 @@ mod tests {
             NodeKind::Cable { from: a, to: b },
             Transform::default(),
         );
-        let node = graph.nodes().iter().find(|n| n.id == cable_id).unwrap();
+        let node = graph.get(cable_id).unwrap();
         assert!(matches!(node.kind, NodeKind::Cable { .. }));
     }
 }

--- a/crates/cplp-gig/src/scene.rs
+++ b/crates/cplp-gig/src/scene.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 /// ノードを一意に識別する ID。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct NodeId(pub u32);
+pub struct NodeId(pub(crate) u32);
 
 /// 3D トランスフォーム（位置・回転・スケール）。
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/cplp-gig/src/scene.rs
+++ b/crates/cplp-gig/src/scene.rs
@@ -1,0 +1,145 @@
+//! SceneGraph – プラットフォーム非依存のシーンデータ構造
+//!
+//! GPU への依存を一切持たない。Clone・Debug を実装し、
+//! スナップショットテストや状態保存が容易。
+
+/// ノードを一意に識別する ID。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeId(pub u32);
+
+/// 3D トランスフォーム（位置・回転・スケール）。
+#[derive(Debug, Clone, PartialEq)]
+pub struct Transform {
+    /// ワールド空間での位置 [x, y, z]
+    pub position: [f32; 3],
+    /// 回転クォータニオン [x, y, z, w]（正規化済み）
+    pub rotation: [f32; 4],
+    /// スケール [x, y, z]
+    pub scale: [f32; 3],
+}
+
+impl Default for Transform {
+    fn default() -> Self {
+        Self {
+            position: [0.0, 0.0, 0.0],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            scale: [1.0, 1.0, 1.0],
+        }
+    }
+}
+
+impl Transform {
+    pub fn at(position: [f32; 3]) -> Self {
+        Self {
+            position,
+            ..Default::default()
+        }
+    }
+}
+
+/// シーンに配置できるノードの種別。
+#[derive(Debug, Clone, PartialEq)]
+pub enum NodeKind {
+    /// ラックユニット（シンセ・エフェクタなど）。
+    RackUnit {
+        /// 機材名（表示用）
+        name: String,
+        /// アクティブ状態（音が出ているか）
+        active: bool,
+        /// 占有ラックユニット数（高さの基準）
+        rack_units: u32,
+    },
+    /// ケーブル（2 ノード間の接続）。
+    Cable {
+        from: NodeId,
+        to: NodeId,
+    },
+    /// 背景プレーン。
+    Background,
+}
+
+/// SceneGraph の 1 ノード。
+#[derive(Debug, Clone)]
+pub struct SceneNode {
+    pub id: NodeId,
+    pub kind: NodeKind,
+    pub transform: Transform,
+}
+
+/// シーン全体を保持するグラフ。
+///
+/// GPU オブジェクトへの参照を持たない。
+/// バックエンドへの送信前に `build_draw_calls` でジオメトリ情報へ変換する。
+#[derive(Debug, Clone, Default)]
+pub struct SceneGraph {
+    nodes: Vec<SceneNode>,
+    next_id: u32,
+}
+
+impl SceneGraph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// ノードを追加し、割り当てた `NodeId` を返す。
+    pub fn add_node(&mut self, kind: NodeKind, transform: Transform) -> NodeId {
+        let id = NodeId(self.next_id);
+        self.next_id += 1;
+        self.nodes.push(SceneNode { id, kind, transform });
+        id
+    }
+
+    /// 指定 ID のノードを削除する。存在しない場合は何もしない。
+    pub fn remove_node(&mut self, id: NodeId) {
+        self.nodes.retain(|n| n.id != id);
+    }
+
+    /// 指定 ID のノードへの可変参照を返す。
+    pub fn get_mut(&mut self, id: NodeId) -> Option<&mut SceneNode> {
+        self.nodes.iter_mut().find(|n| n.id == id)
+    }
+
+    /// 全ノードのスライスを返す。
+    pub fn nodes(&self) -> &[SceneNode] {
+        &self.nodes
+    }
+
+    /// 全ノードをクリアする。
+    pub fn clear(&mut self) {
+        self.nodes.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_and_remove_node() {
+        let mut graph = SceneGraph::new();
+        let id = graph.add_node(
+            NodeKind::RackUnit {
+                name: "Surge XT".into(),
+                active: true,
+                rack_units: 2,
+            },
+            Transform::at([0.0, 0.0, -1.0]),
+        );
+        assert_eq!(graph.nodes().len(), 1);
+        graph.remove_node(id);
+        assert!(graph.nodes().is_empty());
+    }
+
+    #[test]
+    fn cable_references_nodes() {
+        let mut graph = SceneGraph::new();
+        let a = graph.add_node(NodeKind::Background, Transform::default());
+        let b = graph.add_node(NodeKind::Background, Transform::default());
+        let cable_id = graph.add_node(
+            NodeKind::Cable { from: a, to: b },
+            Transform::default(),
+        );
+        let node = graph.nodes().iter().find(|n| n.id == cable_id).unwrap();
+        assert!(matches!(node.kind, NodeKind::Cable { .. }));
+    }
+}

--- a/crates/cplp-gig/src/wgpu_backend.rs
+++ b/crates/cplp-gig/src/wgpu_backend.rs
@@ -1,0 +1,322 @@
+//! wgpu バックエンド – `feature = "wgpu"` でのみコンパイルされる
+//!
+//! `RenderBackend` トレイトの wgpu 実装。
+//! macOS・Linux・Windows 向けのデフォルトバックエンド。
+//! visionOS 向けは将来 `metal_backend.rs` / `realitykit_backend.rs` を追加する。
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use wgpu::util::DeviceExt;
+
+use crate::mesh::{MeshData, Vertex};
+use crate::render_backend::{DrawCall, MeshHandle, RenderBackend};
+
+/// wgpu でアップロード済みのメッシュバッファ。
+struct GpuMesh {
+    vertex_buf: wgpu::Buffer,
+    index_buf: wgpu::Buffer,
+    index_count: u32,
+}
+
+/// wgpu を用いた `RenderBackend` 実装。
+pub struct WgpuBackend {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    surface: wgpu::Surface<'static>,
+    config: wgpu::SurfaceConfiguration,
+    pipeline: wgpu::RenderPipeline,
+    uniform_buf: wgpu::Buffer,
+    uniform_bind_group: wgpu::BindGroup,
+    meshes: HashMap<u32, GpuMesh>,
+    next_handle: u32,
+    width: u32,
+    height: u32,
+}
+
+impl WgpuBackend {
+    /// ウィンドウから WgpuBackend を初期化する。
+    pub fn new(window: Arc<winit::window::Window>) -> anyhow::Result<Self> {
+        let size = window.inner_size();
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY,
+            ..Default::default()
+        });
+        let surface = instance.create_surface(window)?;
+        let adapter = pollster::block_on(instance.request_adapter(
+            &wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::LowPower,
+                compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
+            },
+        ))?;
+        let (device, queue) = pollster::block_on(
+            adapter.request_device(&wgpu::DeviceDescriptor::default())
+        )?;
+
+        let config = surface
+            .get_default_config(&adapter, size.width, size.height)
+            .ok_or_else(|| anyhow::anyhow!("Surface not compatible"))?;
+        surface.configure(&device, &config);
+
+        // ── ユニフォームバッファ（カメラ行列）──────────────────────────────
+        let uniform_data = [0u8; 64]; // 4×4 f32 行列 = 64 バイト
+        let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("gig_uniform"),
+            contents: &uniform_data,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let bind_group_layout = device.create_bind_group_layout(
+            &wgpu::BindGroupLayoutDescriptor {
+                label: Some("gig_bgl"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            },
+        );
+        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gig_bg"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buf.as_entire_binding(),
+            }],
+        });
+
+        // ── シェーダー & パイプライン ────────────────────────────────────
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("gig_shader"),
+            source: wgpu::ShaderSource::Wgsl(GIG_SHADER.into()),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gig_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("gig_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[vertex_buffer_layout()],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: config.format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                cull_mode: Some(wgpu::Face::Back),
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        Ok(Self {
+            device,
+            queue,
+            surface,
+            config,
+            pipeline,
+            uniform_buf,
+            uniform_bind_group,
+            meshes: HashMap::new(),
+            next_handle: 0,
+            width: size.width,
+            height: size.height,
+        })
+    }
+
+    /// カメラのビュー-プロジェクション行列をユニフォームバッファに書き込む。
+    ///
+    /// 現状は固定の俯瞰カメラ（簡易透視投影）。
+    fn update_camera(&self) {
+        // 簡易: 単位行列（将来は実際のカメラ行列を計算）
+        let identity: [[f32; 4]; 4] = [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+        let bytes = bytemuck::cast_slice(&identity);
+        self.queue.write_buffer(&self.uniform_buf, 0, bytes);
+    }
+}
+
+impl RenderBackend for WgpuBackend {
+    fn upload_mesh(&mut self, mesh: &MeshData) -> MeshHandle {
+        let handle_id = self.next_handle;
+        self.next_handle += 1;
+
+        let vertex_bytes: &[u8] = bytemuck::cast_slice(&mesh.vertices);
+        let vertex_buf = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("gig_vb"),
+            contents: vertex_bytes,
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let index_bytes: &[u8] = bytemuck::cast_slice(&mesh.indices);
+        let index_buf = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("gig_ib"),
+            contents: index_bytes,
+            usage: wgpu::BufferUsages::INDEX,
+        });
+
+        self.meshes.insert(
+            handle_id,
+            GpuMesh {
+                vertex_buf,
+                index_buf,
+                index_count: mesh.indices.len() as u32,
+            },
+        );
+
+        MeshHandle(handle_id)
+    }
+
+    fn free_mesh(&mut self, handle: MeshHandle) {
+        if let Some(gpu_mesh) = self.meshes.remove(&handle.0) {
+            gpu_mesh.vertex_buf.destroy();
+            gpu_mesh.index_buf.destroy();
+        }
+    }
+
+    fn submit_frame(&mut self, draw_calls: &[DrawCall]) {
+        self.update_camera();
+
+        let output = match self.surface.get_current_texture() {
+            Ok(t) => t,
+            Err(wgpu::SurfaceError::Lost) => {
+                self.surface.configure(&self.device, &self.config);
+                return;
+            }
+            Err(e) => {
+                tracing::warn!("gig surface error: {:?}", e);
+                return;
+            }
+        };
+        let view = output.texture.create_view(&Default::default());
+        let mut encoder = self.device.create_command_encoder(&Default::default());
+
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("gig_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.05,
+                            g: 0.05,
+                            b: 0.08,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                ..Default::default()
+            });
+
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &self.uniform_bind_group, &[]);
+
+            for call in draw_calls {
+                if let Some(gpu_mesh) = self.meshes.get(&call.mesh.0) {
+                    pass.set_vertex_buffer(0, gpu_mesh.vertex_buf.slice(..));
+                    pass.set_index_buffer(
+                        gpu_mesh.index_buf.slice(..),
+                        wgpu::IndexFormat::Uint32,
+                    );
+                    pass.draw_indexed(0..gpu_mesh.index_count, 0, 0..1);
+                }
+            }
+        }
+
+        self.queue.submit(std::iter::once(encoder.finish()));
+        output.present();
+    }
+
+    fn resize(&mut self, width: u32, height: u32) {
+        if width > 0 && height > 0 {
+            self.width = width;
+            self.height = height;
+            self.config.width = width;
+            self.config.height = height;
+            self.surface.configure(&self.device, &self.config);
+        }
+    }
+}
+
+fn vertex_buffer_layout() -> wgpu::VertexBufferLayout<'static> {
+    wgpu::VertexBufferLayout {
+        array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+        step_mode: wgpu::VertexStepMode::Vertex,
+        attributes: &[
+            // position
+            wgpu::VertexAttribute { offset: 0, shader_location: 0, format: wgpu::VertexFormat::Float32x3 },
+            // normal
+            wgpu::VertexAttribute { offset: 12, shader_location: 1, format: wgpu::VertexFormat::Float32x3 },
+            // uv
+            wgpu::VertexAttribute { offset: 24, shader_location: 2, format: wgpu::VertexFormat::Float32x2 },
+            // color
+            wgpu::VertexAttribute { offset: 32, shader_location: 3, format: wgpu::VertexFormat::Float32x4 },
+        ],
+    }
+}
+
+const GIG_SHADER: &str = r#"
+struct Uniforms {
+    view_proj: mat4x4<f32>,
+}
+@group(0) @binding(0)
+var<uniform> uniforms: Uniforms;
+
+struct VertexIn {
+    @location(0) position: vec3<f32>,
+    @location(1) normal:   vec3<f32>,
+    @location(2) uv:       vec2<f32>,
+    @location(3) color:    vec4<f32>,
+}
+
+struct VertexOut {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+@vertex
+fn vs_main(in: VertexIn) -> VertexOut {
+    var out: VertexOut;
+    out.clip_position = uniforms.view_proj * vec4<f32>(in.position, 1.0);
+    // 簡易ランバート照明（光源方向: 上方向固定）
+    let light = vec3<f32>(0.0, 1.0, 0.5);
+    let diff = max(dot(normalize(in.normal), normalize(light)), 0.15);
+    out.color = vec4<f32>(in.color.rgb * diff, in.color.a);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    return in.color;
+}
+"#;

--- a/crates/cplp-gig/src/wgpu_backend.rs
+++ b/crates/cplp-gig/src/wgpu_backend.rs
@@ -26,8 +26,9 @@ pub struct WgpuBackend {
     surface: wgpu::Surface<'static>,
     config: wgpu::SurfaceConfiguration,
     pipeline: wgpu::RenderPipeline,
-    uniform_buf: wgpu::Buffer,
-    uniform_bind_group: wgpu::BindGroup,
+    /// ビュー-プロジェクション行列を保持するユニフォームバッファ
+    view_proj_buf: wgpu::Buffer,
+    view_proj_bind_group: wgpu::BindGroup,
     meshes: HashMap<u32, GpuMesh>,
     next_handle: u32,
     width: u32,
@@ -50,24 +51,33 @@ impl WgpuBackend {
                 force_fallback_adapter: false,
             },
         ))?;
-        let (device, queue) = pollster::block_on(
-            adapter.request_device(&wgpu::DeviceDescriptor::default())
-        )?;
+
+        // プッシュ定数を有効化してモデル行列をドローコールごとに渡せるようにする
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                required_features: wgpu::Features::PUSH_CONSTANTS,
+                required_limits: wgpu::Limits {
+                    max_push_constant_size: 64, // 4×4 f32 行列 = 64 バイト
+                    ..wgpu::Limits::downlevel_defaults()
+                },
+                ..Default::default()
+            },
+        ))?;
 
         let config = surface
             .get_default_config(&adapter, size.width, size.height)
             .ok_or_else(|| anyhow::anyhow!("Surface not compatible"))?;
         surface.configure(&device, &config);
 
-        // ── ユニフォームバッファ（カメラ行列）──────────────────────────────
-        let uniform_data = [0u8; 64]; // 4×4 f32 行列 = 64 バイト
-        let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("gig_uniform"),
-            contents: &uniform_data,
+        // ── ビュー-プロジェクション行列ユニフォームバッファ ─────────────────
+        let vp_data = [0u8; 64]; // 4×4 f32 = 64 バイト
+        let view_proj_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("gig_view_proj"),
+            contents: &vp_data,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
-        let bind_group_layout = device.create_bind_group_layout(
-            &wgpu::BindGroupLayoutDescriptor {
+        let bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("gig_bgl"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
@@ -79,14 +89,13 @@ impl WgpuBackend {
                     },
                     count: None,
                 }],
-            },
-        );
-        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            });
+        let view_proj_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("gig_bg"),
             layout: &bind_group_layout,
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
-                resource: uniform_buf.as_entire_binding(),
+                resource: view_proj_buf.as_entire_binding(),
             }],
         });
 
@@ -96,11 +105,16 @@ impl WgpuBackend {
             source: wgpu::ShaderSource::Wgsl(GIG_SHADER.into()),
         });
 
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("gig_pipeline_layout"),
-            bind_group_layouts: &[&bind_group_layout],
-            push_constant_ranges: &[],
-        });
+        let pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("gig_pipeline_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                // プッシュ定数: 頂点シェーダーにモデル行列 (64 バイト) を渡す
+                push_constant_ranges: &[wgpu::PushConstantRange {
+                    stages: wgpu::ShaderStages::VERTEX,
+                    range: 0..64,
+                }],
+            });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("gig_pipeline"),
@@ -138,8 +152,8 @@ impl WgpuBackend {
             surface,
             config,
             pipeline,
-            uniform_buf,
-            uniform_bind_group,
+            view_proj_buf,
+            view_proj_bind_group,
             meshes: HashMap::new(),
             next_handle: 0,
             width: size.width,
@@ -149,17 +163,16 @@ impl WgpuBackend {
 
     /// カメラのビュー-プロジェクション行列をユニフォームバッファに書き込む。
     ///
-    /// 現状は固定の俯瞰カメラ（簡易透視投影）。
-    fn update_camera(&self) {
-        // 簡易: 単位行列（将来は実際のカメラ行列を計算）
+    /// 現状は固定の単位行列（将来は実際のカメラ行列を計算する）。
+    fn update_view_proj(&self) {
         let identity: [[f32; 4]; 4] = [
             [1.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 0.0, 0.0],
             [0.0, 0.0, 1.0, 0.0],
             [0.0, 0.0, 0.0, 1.0],
         ];
-        let bytes = bytemuck::cast_slice(&identity);
-        self.queue.write_buffer(&self.uniform_buf, 0, bytes);
+        self.queue
+            .write_buffer(&self.view_proj_buf, 0, bytemuck::cast_slice(&identity));
     }
 }
 
@@ -168,19 +181,20 @@ impl RenderBackend for WgpuBackend {
         let handle_id = self.next_handle;
         self.next_handle += 1;
 
-        let vertex_bytes: &[u8] = bytemuck::cast_slice(&mesh.vertices);
-        let vertex_buf = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("gig_vb"),
-            contents: vertex_bytes,
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-
-        let index_bytes: &[u8] = bytemuck::cast_slice(&mesh.indices);
-        let index_buf = self.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("gig_ib"),
-            contents: index_bytes,
-            usage: wgpu::BufferUsages::INDEX,
-        });
+        let vertex_buf =
+            self.device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("gig_vb"),
+                    contents: bytemuck::cast_slice(&mesh.vertices),
+                    usage: wgpu::BufferUsages::VERTEX,
+                });
+        let index_buf =
+            self.device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("gig_ib"),
+                    contents: bytemuck::cast_slice(&mesh.indices),
+                    usage: wgpu::BufferUsages::INDEX,
+                });
 
         self.meshes.insert(
             handle_id,
@@ -190,7 +204,6 @@ impl RenderBackend for WgpuBackend {
                 index_count: mesh.indices.len() as u32,
             },
         );
-
         MeshHandle(handle_id)
     }
 
@@ -202,7 +215,7 @@ impl RenderBackend for WgpuBackend {
     }
 
     fn submit_frame(&mut self, draw_calls: &[DrawCall]) {
-        self.update_camera();
+        self.update_view_proj();
 
         let output = match self.surface.get_current_texture() {
             Ok(t) => t,
@@ -239,10 +252,16 @@ impl RenderBackend for WgpuBackend {
             });
 
             pass.set_pipeline(&self.pipeline);
-            pass.set_bind_group(0, &self.uniform_bind_group, &[]);
+            pass.set_bind_group(0, &self.view_proj_bind_group, &[]);
 
             for call in draw_calls {
                 if let Some(gpu_mesh) = self.meshes.get(&call.mesh.0) {
+                    // モデル行列をプッシュ定数でシェーダーに渡す（ドローコールごと）
+                    pass.set_push_constants(
+                        wgpu::ShaderStages::VERTEX,
+                        0,
+                        bytemuck::cast_slice(&call.transform),
+                    );
                     pass.set_vertex_buffer(0, gpu_mesh.vertex_buf.slice(..));
                     pass.set_index_buffer(
                         gpu_mesh.index_buf.slice(..),
@@ -273,24 +292,24 @@ fn vertex_buffer_layout() -> wgpu::VertexBufferLayout<'static> {
         array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
         step_mode: wgpu::VertexStepMode::Vertex,
         attributes: &[
-            // position
-            wgpu::VertexAttribute { offset: 0, shader_location: 0, format: wgpu::VertexFormat::Float32x3 },
-            // normal
-            wgpu::VertexAttribute { offset: 12, shader_location: 1, format: wgpu::VertexFormat::Float32x3 },
-            // uv
-            wgpu::VertexAttribute { offset: 24, shader_location: 2, format: wgpu::VertexFormat::Float32x2 },
-            // color
-            wgpu::VertexAttribute { offset: 32, shader_location: 3, format: wgpu::VertexFormat::Float32x4 },
+            wgpu::VertexAttribute { offset: 0,  shader_location: 0, format: wgpu::VertexFormat::Float32x3 }, // position
+            wgpu::VertexAttribute { offset: 12, shader_location: 1, format: wgpu::VertexFormat::Float32x3 }, // normal
+            wgpu::VertexAttribute { offset: 24, shader_location: 2, format: wgpu::VertexFormat::Float32x2 }, // uv
+            wgpu::VertexAttribute { offset: 32, shader_location: 3, format: wgpu::VertexFormat::Float32x4 }, // color
         ],
     }
 }
 
 const GIG_SHADER: &str = r#"
+// ビュー-プロジェクション行列（フレームごとに1回更新）
 struct Uniforms {
     view_proj: mat4x4<f32>,
 }
 @group(0) @binding(0)
 var<uniform> uniforms: Uniforms;
+
+// モデル行列（ドローコールごとにプッシュ定数で更新）
+var<push_constant> model: mat4x4<f32>;
 
 struct VertexIn {
     @location(0) position: vec3<f32>,
@@ -307,7 +326,8 @@ struct VertexOut {
 @vertex
 fn vs_main(in: VertexIn) -> VertexOut {
     var out: VertexOut;
-    out.clip_position = uniforms.view_proj * vec4<f32>(in.position, 1.0);
+    // ビュー-プロジェクション × モデル × 頂点位置
+    out.clip_position = uniforms.view_proj * model * vec4<f32>(in.position, 1.0);
     // 簡易ランバート照明（光源方向: 上方向固定）
     let light = vec3<f32>(0.0, 1.0, 0.5);
     let diff = max(dot(normalize(in.normal), normalize(light)), 0.15);

--- a/crates/cplp-gig/src/wgpu_backend.rs
+++ b/crates/cplp-gig/src/wgpu_backend.rs
@@ -5,6 +5,7 @@
 //! visionOS 向けは将来 `metal_backend.rs` / `realitykit_backend.rs` を追加する。
 
 use std::collections::HashMap;
+use std::num::NonZero;
 use std::sync::Arc;
 
 use wgpu::util::DeviceExt;
@@ -31,8 +32,6 @@ pub struct WgpuBackend {
     view_proj_bind_group: wgpu::BindGroup,
     meshes: HashMap<u32, GpuMesh>,
     next_handle: u32,
-    width: u32,
-    height: u32,
 }
 
 impl WgpuBackend {
@@ -52,14 +51,9 @@ impl WgpuBackend {
             },
         ))?;
 
-        // プッシュ定数を有効化してモデル行列をドローコールごとに渡せるようにする
         let (device, queue) = pollster::block_on(adapter.request_device(
             &wgpu::DeviceDescriptor {
-                required_features: wgpu::Features::PUSH_CONSTANTS,
-                required_limits: wgpu::Limits {
-                    max_push_constant_size: 64, // 4×4 f32 行列 = 64 バイト
-                    ..wgpu::Limits::downlevel_defaults()
-                },
+                required_limits: wgpu::Limits::downlevel_defaults(),
                 ..Default::default()
             },
         ))?;
@@ -109,11 +103,8 @@ impl WgpuBackend {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("gig_pipeline_layout"),
                 bind_group_layouts: &[&bind_group_layout],
-                // プッシュ定数: 頂点シェーダーにモデル行列 (64 バイト) を渡す
-                push_constant_ranges: &[wgpu::PushConstantRange {
-                    stages: wgpu::ShaderStages::VERTEX,
-                    range: 0..64,
-                }],
+                // immediate data: 頂点シェーダーにモデル行列 (64 バイト) を渡す
+                immediate_size: 64,
             });
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -142,7 +133,7 @@ impl WgpuBackend {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            multiview: None,
+            multiview_mask: NonZero::new(0),
             cache: None,
         });
 
@@ -156,8 +147,6 @@ impl WgpuBackend {
             view_proj_bind_group,
             meshes: HashMap::new(),
             next_handle: 0,
-            width: size.width,
-            height: size.height,
         })
     }
 
@@ -256,12 +245,8 @@ impl RenderBackend for WgpuBackend {
 
             for call in draw_calls {
                 if let Some(gpu_mesh) = self.meshes.get(&call.mesh.0) {
-                    // モデル行列をプッシュ定数でシェーダーに渡す（ドローコールごと）
-                    pass.set_push_constants(
-                        wgpu::ShaderStages::VERTEX,
-                        0,
-                        bytemuck::cast_slice(&call.transform),
-                    );
+                    // モデル行列を immediate data でシェーダーに渡す（ドローコールごと）
+                    pass.set_immediates(0, bytemuck::cast_slice(&call.transform));
                     pass.set_vertex_buffer(0, gpu_mesh.vertex_buf.slice(..));
                     pass.set_index_buffer(
                         gpu_mesh.index_buf.slice(..),
@@ -278,8 +263,6 @@ impl RenderBackend for WgpuBackend {
 
     fn resize(&mut self, width: u32, height: u32) {
         if width > 0 && height > 0 {
-            self.width = width;
-            self.height = height;
             self.config.width = width;
             self.config.height = height;
             self.surface.configure(&self.device, &self.config);

--- a/docs/design/2026-03-08-gig-scene-visionos-design.md
+++ b/docs/design/2026-03-08-gig-scene-visionos-design.md
@@ -1,0 +1,162 @@
+# Gig Scene – visionOS 対応アーキテクチャ設計
+
+**作成日**: 2026-03-08
+**対象イシュー**: #26
+**ラベル**: gig, infra
+
+---
+
+## 概要
+
+`cplp-gig` クレートは、ライブセッション中の機材ラック・ケーブルパッチを 3D で可視化する
+「Gig Scene」機能を担う。将来的に Apple Vision Pro（visionOS）でも動作させるため、
+**シーングラフ**・**メッシュ生成**・**GPU パイプライン** を明確に分離した設計とする。
+
+---
+
+## 問題設定
+
+単一の `app.rs` / `mesh.rs` にシーンデータと GPU 依存コードを混在させると、
+visionOS ポーティング時に次の問題が生じる。
+
+| 問題 | 影響 |
+|------|------|
+| `wgpu` の `Surface` 作成が winit ウィンドウに依存 | visionOS では `CompositorLayer` を使う必要がある |
+| メッシュデータと GPU バッファが同一型に紐づく | バックエンド切替でシーンデータの書き直しが必要 |
+| テストが GPU デバイス初期化を必要とする | CI での単体テストが困難 |
+
+---
+
+## アーキテクチャ
+
+```
+cplp-gig
+├── scene.rs          ← SceneGraph（GPU 非依存）
+├── mesh.rs           ← メッシュ生成（GPU 非依存）
+├── render_backend.rs ← RenderBackend trait（抽象層）
+└── wgpu_backend.rs   ← wgpu 実装（feature = "wgpu" でのみコンパイル）
+```
+
+### レイヤー図
+
+```
+┌─────────────────────────────┐
+│       SceneGraph            │  platform-agnostic
+│  (scene.rs)                 │  ノード・トランスフォーム
+└──────────┬──────────────────┘
+           │ build_draw_calls()
+┌──────────▼──────────────────┐
+│       MeshData              │  platform-agnostic
+│  (mesh.rs)                  │  頂点・インデックス生成
+└──────────┬──────────────────┘
+           │ upload_mesh() / submit_frame()
+┌──────────▼──────────────────┐
+│     RenderBackend trait     │  抽象層
+│  (render_backend.rs)        │
+├─────────────────────────────┤
+│  WgpuBackend (wgpu feat.)   │  macOS / Linux / Windows
+│  [将来] MetalBackend        │  visionOS / RealityKit
+└─────────────────────────────┘
+```
+
+---
+
+## モジュール詳細
+
+### `scene.rs` – SceneGraph
+
+プラットフォーム非依存のシーンデータ構造。`wgpu` への依存ゼロ。
+
+```
+SceneGraph
+  └── Vec<SceneNode>
+        ├── NodeId      (u32 newtype)
+        ├── Transform   { position, rotation(quaternion), scale }
+        └── NodeKind
+              ├── RackUnit { name, active, rack_units }
+              ├── Cable    { from: NodeId, to: NodeId }
+              └── Background
+```
+
+**設計方針**:
+- `Clone + Debug` を実装し、テスト・スナップショットを容易にする
+- GPU オブジェクトへの参照を一切持たない
+
+### `mesh.rs` – メッシュ生成
+
+シーンノードから `MeshData`（頂点・インデックス列）を生成するロジック。
+GPU バッファアップロードは行わない。
+
+```rust
+pub struct Vertex {
+    pub position: [f32; 3],
+    pub normal:   [f32; 3],
+    pub uv:       [f32; 2],
+    pub color:    [f32; 4],
+}
+
+pub struct MeshData {
+    pub vertices: Vec<Vertex>,
+    pub indices:  Vec<u32>,
+}
+```
+
+**設計方針**:
+- 純粋関数で実装 → 単体テストがシンプル
+- `bytemuck::Pod` を `Vertex` に実装し、将来のバッファ書き込みを効率化
+
+### `render_backend.rs` – RenderBackend trait
+
+バックエンド非依存の描画インターフェース。
+
+```rust
+pub trait RenderBackend {
+    fn upload_mesh(&mut self, mesh: &MeshData) -> MeshHandle;
+    fn free_mesh(&mut self, handle: MeshHandle);
+    fn submit_frame(&mut self, draw_calls: &[DrawCall]);
+    fn resize(&mut self, width: u32, height: u32);
+}
+```
+
+**`DrawCall`**:
+```rust
+pub struct DrawCall {
+    pub mesh:      MeshHandle,
+    pub transform: [[f32; 4]; 4],  // 列優先4×4行列
+}
+```
+
+### `wgpu_backend.rs` – wgpu 実装
+
+`feature = "wgpu"` でのみコンパイルされる。`RenderBackend` を `wgpu` で実装する。
+visionOS 向けには別途 `metal_backend.rs` / `realitykit_backend.rs` を追加する想定。
+
+---
+
+## Cargo.toml 方針
+
+```toml
+[features]
+default = ["wgpu"]
+wgpu = ["dep:wgpu", "dep:winit", "dep:pollster", "dep:bytemuck"]
+```
+
+visionOS ビルド時は `default-features = false` として `wgpu` を外し、
+プラットフォーム固有バックエンドのみをリンクする。
+
+---
+
+## テスト方針
+
+- `scene.rs` / `mesh.rs` のユニットテストは GPU デバイス不要
+- `wgpu_backend.rs` の統合テストは `#[cfg(feature = "wgpu")]` でガード
+
+---
+
+## 将来の拡張
+
+| フェーズ | 内容 |
+|----------|------|
+| D-1 | 本設計（シーン/レンダリング分離） |
+| D-2 | visionOS CompositorLayer 上の MetalBackend 実装 |
+| D-3 | RealityKit アンカー連携（空間音響マッピング） |


### PR DESCRIPTION
## 概要

Issue #26「シーン / レンダリング分離（visionOS 準備）」への対応。

新規クレート `cplp-gig` を追加し、SceneGraph・メッシュ生成・GPU パイプラインを明確に分離した。
visionOS 向けビルド時は `feature = "wgpu"` を外すだけで wgpu 依存を完全除去できる設計になっている。

---

## チェックボックス対応

- [x] SceneGraph データ構造を app.rs / mesh.rs から独立させる
- [x] RenderBackend trait の導入
- [x] メッシュ生成ロジック（プラットフォーム非依存）と GPU パイプライン（wgpu 依存）の分離

---

## ファイル構成

```
crates/cplp-gig/
├── Cargo.toml                   # feature = "wgpu" で GPU 依存を制御
└── src/
    ├── lib.rs
    ├── scene.rs                 # SceneGraph（GPU 依存ゼロ）
    ├── mesh.rs                  # メッシュ生成ロジック（GPU 依存ゼロ）
    ├── render_backend.rs        # RenderBackend trait + DrawCall + build_draw_calls
    └── wgpu_backend.rs          # wgpu 実装（feature = "wgpu" のみコンパイル）

docs/design/2026-03-08-gig-scene-visionos-design.md  # 設計ドキュメント
```

---

## アーキテクチャ概要

```
SceneGraph (scene.rs)
  ↓ build_draw_calls()
MeshData (mesh.rs)
  ↓ upload_mesh() / submit_frame()
RenderBackend trait (render_backend.rs)
  ├── WgpuBackend   ← 現在実装済み（macOS/Linux/Windows）
  └── [将来] MetalBackend / RealityKitBackend（visionOS）
```

---

## 主な修正・改善点

- **wgpu v28 対応**: push constants → immediate data API へ移行（`immediate_size` / `set_immediates`）
- **ケーブルメッシュ法線**: フラットシェーディング化（面ごとに専用頂点を割り当て、面法線を正確に計算）
- **NodeId**: 内部フィールドを `pub(crate)` に変更し、外部クレートからの任意構築を防止
- **未使用フィールド削除**: `WgpuBackend` の `width` / `height` フィールドを削除

---

## テスト

GPU デバイス不要のユニットテストを各モジュールに追加済み（全 11 件）。

- `scene.rs`: ノード追加・削除・ケーブル参照・swap_remove 後の lookup 整合性
- `mesh.rs`: 頂点数・インデックス数・アクティブ時の色・縮退ケーブル
- `render_backend.rs`: `build_draw_calls` のノードマッピング・欠損ノードのスキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)